### PR TITLE
get past events on interval to have fallback if websockets stop working

### DIFF
--- a/modules/listeners/index.js
+++ b/modules/listeners/index.js
@@ -5,8 +5,12 @@ const init = (osseus) => {
       osseus.logger.warn(`Listeners skipped`)
       return resolve()
     }
-    await require('./models/transfer')(osseus).getPastEvents()
-    await require('./models/transfer')(osseus).init()
+    const transferListener = require('./models/transfer')(osseus)
+    const pastEventsInterval = parseInt((osseus.config.past_events_interval || 10000), 10)
+    setInterval(async () => {
+      await transferListener.getPastEvents()
+    }, pastEventsInterval)
+    await transferListener.init()
     osseus.logger.info(`Listeners ready`)
     resolve()
   })

--- a/modules/listeners/models/transfer.js
+++ b/modules/listeners/models/transfer.js
@@ -68,6 +68,7 @@ module.exports = (osseus) => {
 
   return {
     init: async () => {
+      osseus.logger.silly(`Transfer events listener - init`)
       const currencies = await osseus.db_models.currency.getAllCCs()
       if (!currencies || currencies.length === 0) {
         osseus.logger.warn(`Transfer events listener - init - no currencies`)
@@ -87,6 +88,7 @@ module.exports = (osseus) => {
     },
 
     getPastEvents: async () => {
+      osseus.logger.silly(`Transfer events listener - getPastEvents`)
       const currencies = await osseus.db_models.currency.getAllCCs()
       if (!currencies || currencies.length === 0) {
         osseus.logger.warn(`Transfer events listener - getPastEvents - no currencies`)
@@ -97,8 +99,8 @@ module.exports = (osseus) => {
         const address = currency.currencyAddress
         const abi = JSON.parse(currency.currencyABI)
         const creationBlock = currency.currencyBlockchainInfo.blockNumber
-        const currentBlock = await osseus.web3WS.eth.getBlockNumber()
-        const CurrencyContract = new osseus.web3WS.eth.Contract(abi, address)
+        const currentBlock = await osseus.web3.eth.getBlockNumber()
+        const CurrencyContract = new osseus.web3.eth.Contract(abi, address)
         const lastBlock = await osseus.db_models.bcevent.getLastBlock(address)
         let fromBlock = Math.max(lastBlock, creationBlock) + 1
         let toBlock = fromBlock + pastEventsBlockLimit


### PR DESCRIPTION
## Proposed changes

The purpose of this PR is to have a fallback for listening on `transfer` events.
Websockets sometimes disconnect and therefore `getPastEvents` will be called on a configurable interval to monitor events with a slight delay.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/ColuLocalNetwork/inventory-manager/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules